### PR TITLE
Add names to core function parameters

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Http4k.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Http4k.kt
@@ -2,9 +2,9 @@ package org.http4k.core
 
 import org.http4k.routing.RoutingHttpHandler
 
-typealias HttpHandler = (Request) -> Response
+typealias HttpHandler = (request: Request) -> Response
 
-fun interface Filter : (HttpHandler) -> HttpHandler {
+fun interface Filter : (next: HttpHandler) -> HttpHandler {
     companion object
 }
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/Http4k.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Http4k.kt
@@ -4,7 +4,7 @@ import org.http4k.routing.RoutingHttpHandler
 
 typealias HttpHandler = (request: Request) -> Response
 
-fun interface Filter : (next: HttpHandler) -> HttpHandler {
+fun interface Filter : (HttpHandler) -> HttpHandler {
     companion object
 }
 


### PR DESCRIPTION
The compiler bug seems to have been fixed, so I'm having another go